### PR TITLE
Fixed subtract bug

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -90,8 +90,8 @@ public class Main {
                     break;
                 case 3:
                     result = regs[regA] - regs[regB];
-                    regs[regDest] = result & 255;
                     flags[0] = regs[regA] >= regs[regB];
+                    regs[regDest] = result & 255;
                     flags[1] = regs[regDest] == 0;
                     break;
                 case 4:


### PR DESCRIPTION
When subtracting of the destination is either regA or regB the value will be overwritten and you can't use them to check if the carry flag should be set.